### PR TITLE
feat: enable subdirectory backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# IDE related files
+.idea

--- a/src/components/NavigationBar.astro
+++ b/src/components/NavigationBar.astro
@@ -1,5 +1,6 @@
 ---
 const bucketName = import.meta.env.BUCKET;
+const directory = import.meta.env.DIRECTORY;
 ---
 
 <nav>
@@ -7,6 +8,6 @@ const bucketName = import.meta.env.BUCKET;
     <li><strong><a href="/">Pulumi S3 Self-Hosted UI</a></strong></li>
   </ul>
   <ul>
-    <li>{bucketName}</li>
+    <li>{bucketName}{directory ? `/${directory}` : ''}</li>
   </ul>
 </nav>

--- a/src/components/OutputsModal.svelte
+++ b/src/components/OutputsModal.svelte
@@ -1,0 +1,46 @@
+<script>
+  export let outputs = {};
+  export let show = false;
+  export let closeModal;
+</script>
+
+{#if show}
+  <div class="modal-backdrop" on:click={closeModal}></div>
+  <div class="modal">
+    <h1>Resource Outputs</h1>
+    <pre>{JSON.stringify(outputs, null, 2)}</pre>
+    <button on:click={closeModal}>Close</button>
+  </div>
+{/if}
+
+<style>
+    .modal-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 10;
+    }
+    .modal {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: var(--card-background-color);
+        padding: 1rem;
+        border-radius: 8px;
+        z-index: 20;
+        width: 800px;
+        max-width: 100%;
+        max-height: calc(100% - 4rem);
+        overflow-y: auto;
+    }
+    pre {
+        text-align: left;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+        padding: 1rem;
+    }
+</style>

--- a/src/components/Stack.svelte
+++ b/src/components/Stack.svelte
@@ -1,8 +1,14 @@
 <script>
     import { onMount } from "svelte";
+    import OutputsModal from "./OutputsModal.svelte";
+
     export let fileKey = "";
 
     let data;
+    let resources = [];
+    let showModal = false;
+    let selectedOutputs = {};
+
     onMount(async function () {
         const response = await fetch("/api/state", {
             method: "POST",
@@ -11,7 +17,21 @@
         });
         const json = await response.json();
         data = JSON.parse(json.data);
+        console.debug('▶️ Resources list data:', data);
+
+        const resourcesKey = data.checkpoint.latest ? 'latest' : (data.checkpoint.Latest ? 'Latest' : null);
+        resources = data.checkpoint[resourcesKey].resources;
     });
+
+    function openModal(outputs) {
+        selectedOutputs = outputs;
+        showModal = true;
+    }
+
+    function closeModal() {
+        showModal = false;
+        selectedOutputs = {};
+    }
 </script>
 
 <article aria-busy={fileKey.trim() !== "" ? false : true}>
@@ -23,17 +43,21 @@
                 <th scope="col">Type</th>
                 <th scope="col">Created</th>
                 <th scope="col">Modified</th>
+                <th scope="col">Outputs</th>
             </tr>
         </thead>
         <tbody>
             {#if data}
-                {#each data.checkpoint.latest.resources as resource}
+                {#each resources as resource}
                     {#if resource.id && !resource.type.includes("providers")}
                         <tr>
                             <td>{resource.id}</td>
                             <td>{resource.type}</td>
                             <td>{resource.created}</td>
                             <td>{resource.modified}</td>
+                            <td>
+                                <button on:click={() => openModal(resource.outputs)}>Show</button>
+                            </td>
                         </tr>
                     {/if}
                 {/each}
@@ -42,9 +66,16 @@
     </table>
 </article>
 
+<OutputsModal show={showModal} outputs={selectedOutputs} closeModal={closeModal} />
+
 <style>
     article {
         text-align: center;
         margin: 0;
+    }
+
+    table {
+        width: 100%;
+        overflow-x: auto;
     }
 </style>

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,5 +1,5 @@
 import { S3Helper } from '../utils/s3';
 import { Helper } from '../utils/helper';
 
-export const S3Controller = new S3Helper(import.meta.env.BUCKET);
+export const S3Controller = new S3Helper(import.meta.env.BUCKET, import.meta.env.DIRECTORY);
 export const HelperController = new Helper();

--- a/src/utils/s3/index.ts
+++ b/src/utils/s3/index.ts
@@ -1,3 +1,4 @@
+
 import { S3Client, ListObjectsV2Command, ListObjectsV2Request, _Object, GetObjectRequest, GetObjectCommand } from "@aws-sdk/client-s3";
 import type { EnvironmentObjectType } from "./types";
 import { HelperController } from "../../server/utils";
@@ -6,16 +7,18 @@ export class S3Helper {
   private client = new S3Client({});
   private bucket: string;
   private pulumiStore: string;
+  private directory: string | null;
 
-  constructor(bucket: string) {
+  constructor(bucket: string, directory: string | null = null) {
     this.bucket = bucket;
+    this.directory = directory;
     this.pulumiStore = '.pulumi';
   }
 
   private async getObject(Key: string) {
     const input: GetObjectRequest = {
       Bucket: this.bucket,
-      Key 
+      Key
     };
 
     const command = new GetObjectCommand(input);
@@ -25,7 +28,7 @@ export class S3Helper {
   };
 
   private async listKeys(location: string) {
-    const Prefix = `${this.pulumiStore}/${location}/`;
+    const Prefix = this.directory ? `${this.directory}/${this.pulumiStore}/${location}/` : `${this.pulumiStore}/${location}/`;
     const input: ListObjectsV2Request = {
       Bucket: this.bucket,
       Prefix,
@@ -57,7 +60,7 @@ export class S3Helper {
   }
 
   private async listFolders(location: string) {
-    const Prefix = `${this.pulumiStore}/${location}/`;
+    const Prefix = this.directory ? `${this.directory}/${this.pulumiStore}/${location}/` : `${this.pulumiStore}/${location}/`;
     const input: ListObjectsV2Request = {
       Bucket: this.bucket,
       Delimiter: `/`,


### PR DESCRIPTION
# Description

Currently, the custom S3 backend must be the root of the bucket.
Pulumi supports using subdirectories as the backend root. This PR adds support for this while maintaining the ability for bucket-root backends. Also support to display a resources output in a modal was added

* chore: add IDE related files section to gitignore & blacklist jetbrains .idea dir
* feat: add outputs modal component
* feat: overall stack optimizations
  * implement outputs modal with outputs data + column in the table
  * temporary log resources data for detailed investigation / development
  * fix issue when `latest` property is `Latest` (reason unknown, either because the encountered incident was an imported stack, either because it was originally an app.pulumi.com backend hosted stack, either because it is an older stack)
* feat: allow subdirectories on a bucket to serve as backends. Should work both at root and with a subdirectory
